### PR TITLE
feat: add elasticsearch index management

### DIFF
--- a/app/Http/Controllers/ElasticsearchIndexController.php
+++ b/app/Http/Controllers/ElasticsearchIndexController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+
+class ElasticsearchIndexController extends Controller
+{
+    protected function client()
+    {
+        $host = config('elasticsearch.host');
+        if (! str_starts_with($host, 'http')) {
+            $host = 'http://' . $host;
+        }
+        $host = rtrim($host, '/');
+
+        $request = Http::baseUrl($host);
+
+        $username = config('elasticsearch.username');
+        $password = config('elasticsearch.password');
+        if ($username && $password) {
+            $request = $request->withBasicAuth($username, $password);
+        }
+
+        return $request;
+    }
+
+    public function index()
+    {
+        $response = $this->client()->get('/_cat/indices', ['format' => 'json']);
+        $indices = $response->successful() ? $response->json() : [];
+
+        return view('elasticsearch.indices', compact('indices'));
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string',
+        ]);
+
+        $this->client()->put('/' . $data['name']);
+
+        return redirect()->route('elasticsearch.indices.index')
+            ->with('status', 'Index created.');
+    }
+
+    public function destroy(string $index)
+    {
+        $this->client()->delete('/' . $index);
+
+        return redirect()->route('elasticsearch.indices.index')
+            ->with('status', 'Index deleted.');
+    }
+}
+

--- a/resources/views/elasticsearch/indices.blade.php
+++ b/resources/views/elasticsearch/indices.blade.php
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Elasticsearch Indices</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container-fluid">
+    <div class="row">
+        <nav class="col-md-2 d-none d-md-block bg-light sidebar">
+            <div class="position-sticky pt-3">
+                <ul class="nav flex-column">
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ route('elasticsearch.settings.edit') }}">Settings</a>
+                    </li>
+                    <li class="nav-item">
+                        <span class="nav-link active">Indices</span>
+                    </li>
+                </ul>
+            </div>
+        </nav>
+        <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
+            <h1 class="mt-4">Elasticsearch Indices</h1>
+            @if(session('status'))
+                <div class="alert alert-success">{{ session('status') }}</div>
+            @endif
+            <form method="POST" action="{{ route('elasticsearch.indices.store') }}" class="mt-4">
+                @csrf
+                <div class="mb-3">
+                    <label class="form-label" for="name">New Index Name</label>
+                    <input class="form-control" type="text" id="name" name="name" required>
+                </div>
+                <button type="submit" class="btn btn-primary">Create</button>
+            </form>
+            <h2 class="mt-5">Existing Indices</h2>
+            <table class="table mt-3">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                @forelse($indices as $index)
+                    <tr>
+                        <td>{{ $index['index'] ?? '' }}</td>
+                        <td>
+                            <form method="POST" action="{{ route('elasticsearch.indices.destroy', $index['index']) }}" onsubmit="return confirm('Delete this index?');">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+                            </form>
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="2">No indices found.</td>
+                    </tr>
+                @endforelse
+                </tbody>
+            </table>
+        </main>
+    </div>
+</div>
+</body>
+</html>

--- a/resources/views/elasticsearch/settings.blade.php
+++ b/resources/views/elasticsearch/settings.blade.php
@@ -13,7 +13,10 @@
             <div class="position-sticky pt-3">
                 <ul class="nav flex-column">
                     <li class="nav-item">
-                        <span class="nav-link active">Elasticsearch</span>
+                        <span class="nav-link active">Settings</span>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ route('elasticsearch.indices.index') }}">Indices</a>
                     </li>
                 </ul>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\ElasticsearchSettingsController;
+use App\Http\Controllers\ElasticsearchIndexController;
 
 /*
 |--------------------------------------------------------------------------
@@ -22,3 +23,10 @@ Route::get('/elasticsearch/settings', [ElasticsearchSettingsController::class, '
     ->name('elasticsearch.settings.edit');
 Route::post('/elasticsearch/settings', [ElasticsearchSettingsController::class, 'update'])
     ->name('elasticsearch.settings.update');
+
+Route::get('/elasticsearch/indices', [ElasticsearchIndexController::class, 'index'])
+    ->name('elasticsearch.indices.index');
+Route::post('/elasticsearch/indices', [ElasticsearchIndexController::class, 'store'])
+    ->name('elasticsearch.indices.store');
+Route::delete('/elasticsearch/indices/{index}', [ElasticsearchIndexController::class, 'destroy'])
+    ->name('elasticsearch.indices.destroy');


### PR DESCRIPTION
## Summary
- allow managing Elasticsearch indices via HTTP client
- expose UI for listing, creating, and deleting indices
- link indices management from settings page

## Testing
- `composer install --no-progress` *(fails: CONNECT tunnel failed, requires GitHub token)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6890cfd280e48333ab8437e1df7a391a