### PR TITLE
Improve Elasticsearch settings persistence and guidance

### DIFF
--- a/app/Http/Controllers/ElasticsearchSettingsController.php
+++ b/app/Http/Controllers/ElasticsearchSettingsController.php
@@ -31,6 +31,13 @@ class ElasticsearchSettingsController extends Controller
 
         $this->updateEnv($data);
 
+        config([
+            'elasticsearch.host' => $data['host'],
+            'elasticsearch.port' => $data['port'],
+            'elasticsearch.username' => $data['username'],
+            'elasticsearch.password' => $data['password'],
+        ]);
+
         return redirect()->route('elasticsearch.settings.edit')->with('status', 'Elasticsearch settings updated.');
     }
 
@@ -52,7 +59,7 @@ class ElasticsearchSettingsController extends Controller
     {
         $envPath = base_path('.env');
         if (!File::exists($envPath)) {
-            return;
+            File::put($envPath, '');
         }
 
         $envContent = File::get($envPath);

--- a/resources/views/elasticsearch/settings.blade.php
+++ b/resources/views/elasticsearch/settings.blade.php
@@ -40,19 +40,21 @@
                         @csrf
                         <div class="mb-3">
                             <label class="form-label" for="host">Host</label>
-                            <input class="form-control" type="text" id="host" name="host" value="{{ old('host', $settings['host']) }}" required>
+                            <input class="form-control" type="text" id="host" name="host" value="{{ old('host', $settings['host']) }}" placeholder="localhost" required>
+                            <div class="form-text">Example: localhost or 127.0.0.1</div>
                         </div>
                         <div class="mb-3">
                             <label class="form-label" for="port">Port</label>
-                            <input class="form-control" type="number" id="port" name="port" value="{{ old('port', $settings['port']) }}" required>
+                            <input class="form-control" type="number" id="port" name="port" value="{{ old('port', $settings['port']) }}" placeholder="9200" required>
+                            <div class="form-text">Default: 9200</div>
                         </div>
                         <div class="mb-3">
                             <label class="form-label" for="username">Username</label>
-                            <input class="form-control" type="text" id="username" name="username" value="{{ old('username', $settings['username']) }}">
+                            <input class="form-control" type="text" id="username" name="username" value="{{ old('username', $settings['username']) }}" placeholder="elastic">
                         </div>
                         <div class="mb-3">
                             <label class="form-label" for="password">Password</label>
-                            <input class="form-control" type="password" id="password" name="password" value="{{ old('password', $settings['password']) }}">
+                            <input class="form-control" type="password" id="password" name="password" value="{{ old('password', $settings['password']) }}" placeholder="secret">
                         </div>
                         <button type="submit" class="btn btn-primary">Save</button>
                     </form>


### PR DESCRIPTION
## Summary
- Add example placeholders and help text for Elasticsearch host, port, username, and password fields.
- Create `.env` file if missing and update runtime configuration after saving settings.

## Testing
- `composer install` *(fails: Required package "elasticsearch/elasticsearch" is not present in the lock file)*
- `composer update` *(fails: CONNECT tunnel failed, response 403)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891258fe2488333970f6fa547c877ad