### PR TITLE
fix: correct Elasticsearch client package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "laravel/sanctum": "^3.3",
         "laravel/tinker": "^2.8",
         "livewire/livewire": "^3.6",
-        "elasticsearch/elasticsearch": "^8.0"
+        "elastic/elasticsearch": "^8.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",


### PR DESCRIPTION
## Summary
- correct composer package name for Elasticsearch PHP client

## Testing
- `composer update elastic/elasticsearch` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68912ce733248333b5089ff5ee1d08ed