### PR TITLE
fix: correct Elasticsearch package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "laravel/sanctum": "^3.3",
         "laravel/tinker": "^2.8",
         "livewire/livewire": "^3.6",
-        "elastic/elasticsearch": "^8.0"
+        "elasticsearch/elasticsearch": "^8.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",


### PR DESCRIPTION
## Summary
- fix Elasticsearch dependency package name

## Testing
- `composer update elasticsearch/elasticsearch` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68913032bc2c83339a8a9b8baabc9029